### PR TITLE
학생 과제 결과에 대화별 피드백 표시 기능 추가

### DIFF
--- a/src/main/java/com/iny/side/chat/domain/entity/ChatMessage.java
+++ b/src/main/java/com/iny/side/chat/domain/entity/ChatMessage.java
@@ -45,12 +45,14 @@ public class ChatMessage {
 
     @Builder
     public ChatMessage(Long id, Submission submission, Integer turnNumber, 
-                      SpeakerType speaker, String message, LocalDateTime timestamp) {
+                      SpeakerType speaker, String message, Integer score, String feedback, LocalDateTime timestamp) {
         this.id = id;
         this.submission = submission;
         this.turnNumber = turnNumber;
         this.speaker = speaker;
         this.message = message;
+        this.score = score;
+        this.feedback = feedback;
         this.timestamp = timestamp;
     }
 

--- a/src/main/java/com/iny/side/evaluation/application/service/StudentEvaluationService.java
+++ b/src/main/java/com/iny/side/evaluation/application/service/StudentEvaluationService.java
@@ -1,8 +1,8 @@
 package com.iny.side.evaluation.application.service;
 
+import com.iny.side.evaluation.web.dto.ChatFeedbackResultDto;
 import com.iny.side.evaluation.web.dto.SummaryResponseDto;
 
 public interface StudentEvaluationService {
     SummaryResponseDto getMySummary(Long studentId, Long assignmentId);
-
 }

--- a/src/main/java/com/iny/side/evaluation/application/service/StudentEvaluationService.java
+++ b/src/main/java/com/iny/side/evaluation/application/service/StudentEvaluationService.java
@@ -1,6 +1,5 @@
 package com.iny.side.evaluation.application.service;
 
-import com.iny.side.evaluation.web.dto.ChatFeedbackResultDto;
 import com.iny.side.evaluation.web.dto.SummaryResponseDto;
 
 public interface StudentEvaluationService {

--- a/src/main/java/com/iny/side/evaluation/web/dto/ChatFeedbackResultDto.java
+++ b/src/main/java/com/iny/side/evaluation/web/dto/ChatFeedbackResultDto.java
@@ -1,0 +1,22 @@
+package com.iny.side.evaluation.web.dto;
+
+import com.iny.side.chat.domain.entity.ChatMessage;
+import com.iny.side.chat.web.dto.ChatMessageResponseDto;
+
+public record ChatFeedbackResultDto(
+        ChatMessageResponseDto studentMessage,
+        ChatMessageResponseDto aiMessage,
+        Integer score,
+        String feedback
+
+) {
+
+    public static ChatFeedbackResultDto from(ChatMessage student, ChatMessage ai) {
+        return new ChatFeedbackResultDto(
+                ChatMessageResponseDto.from(student),
+                ChatMessageResponseDto.from(ai),
+                student.getScore(),
+                student.getFeedback()
+        );
+    }
+}

--- a/src/main/java/com/iny/side/evaluation/web/dto/SummaryResponseDto.java
+++ b/src/main/java/com/iny/side/evaluation/web/dto/SummaryResponseDto.java
@@ -12,17 +12,24 @@ public record SummaryResponseDto(
         String primaryDiagnosis,
         String subDiagnosis,
         List<PrescriptionResponseDto> prescriptions,
-        String finalJudgment
+        String finalJudgment,
+        List<ChatFeedbackResultDto> chatFeedbacks
 ) {
 
-    public static SummaryResponseDto from(Submission submission, Evaluation eval, List<PrescriptionResponseDto> prescriptionDtos) {
+    public static SummaryResponseDto from(
+            Submission submission,
+            Evaluation eval,
+            List<PrescriptionResponseDto> prescriptionDtoList,
+            List<ChatFeedbackResultDto> chatFeedbackResultDtoList
+    ) {
         return new SummaryResponseDto(
                 eval.getScore(),
                 eval.getFeedback(),
                 submission.getPrimaryDiagnosis(),
                 submission.getSubDiagnosis(),
-                prescriptionDtos,
-                submission.getFinalJudgment()
+                prescriptionDtoList,
+                submission.getFinalJudgment(),
+                chatFeedbackResultDtoList
         );
     }
 }


### PR DESCRIPTION
## ✨ 작업 개요
<!-- 어떤 작업을 했는지 한 줄로 설명해주세요 -->
과제 결과 조회 화면에서 대화 피드백 정보를 포함하여 조회할 수 있도록 기능 확장

---

## 📌 관련 이슈
<!-- 이 PR이 해결하는 이슈 번호를 명시해주세요 -->
Closes #11 

---

## 🛠️ 주요 변경 사항
<!-- 변경된 내용을 bullet 형식으로 요약해주세요 -->
- 학생 과제 요약 조회 API에 대화 피드백 데이터 추가
- 대화 메시지를 턴 번호별로 그룹화하여 학생/AI 메시지 페어링 로직 구현
- 메시지 누락 시 예외 처리 로직 추가 ( `IllegalStateException` )
- 다양한 예외 상황에 대한 테스트 케이스 추가

---

## 🧪 테스트 방법
<!-- 직접 확인하거나, QA가 테스트할 수 있도록 설명(화면 테스트) -->
1. 학생으로 로그인 후 완료된 과제의 결과 조회 페이지 진입
2. 기존 정보(점수, 피드백, 진단, 처방전) 정상 표시 확인
3. 새로 추가된 대화 내역 및 각 턴별 피드백 표시 확인
4. 다른 학생의 과제 접근 시 권한 오류 처리 확인

---

## 🤝 리뷰 요청 포인트
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있다면 적어주세요 -->
- 대화 메시지 페어링 로직의 안정성 (턴별 그룹화 및 학생/AI 매칭)
- 예외 처리 방식 (`IllegalStateException` vs 커스텀 예외) 
- `IllegalStateException` 발생되는 게 조회할 때 필요할지(대화 저장 시에 검증하면 충분하지 않은가?)
- `ChatFeedbackResultDto`구조의 적절성 
