### PR TITLE
feat: 학생 과제 목록에 '채점 완료' 상태 표시 기능 추가

### DIFF
--- a/src/main/java/com/iny/side/assignment/application/service/StudentAssignmentServiceImpl.java
+++ b/src/main/java/com/iny/side/assignment/application/service/StudentAssignmentServiceImpl.java
@@ -29,17 +29,14 @@ public class StudentAssignmentServiceImpl implements StudentAssignmentService {
 
     @Override
     public SliceResponse<StudentAssignmentSimpleResponseDto> getAll(Long courseId, Long studentId, int page) {
+        // 1. 권한 검증
         enrollmentValidationService.validateStudentEnrolledInCourse(courseId, studentId);
+        // 2. 페이징 정보 생성
         Pageable pageable = PageRequest.of(page, 12);
+        // 3. repository 에서 과제의 상태가 결정된 상태로 넘어옴
         Slice<StudentAssignmentSimpleResponseDto> assignmentSlice = assignmentRepository.findAllByCourseIdAndStudentId(courseId, studentId, pageable);
 
-        List<StudentAssignmentSimpleResponseDto> content = assignmentSlice.getContent().stream()
-                .map(dto -> dto.status() == null ?
-                    new StudentAssignmentSimpleResponseDto(dto.id(), dto.title(), dto.dueDate(), dto.objective(), Submission.SubmissionStatus.NOT_STARTED) :
-                    dto)
-                .toList();
-
-        return SliceResponse.of(content, page, 12, assignmentSlice.hasNext());
+        return SliceResponse.from(assignmentSlice);
     }
 
     @Override

--- a/src/main/java/com/iny/side/assignment/application/service/StudentAssignmentServiceImpl.java
+++ b/src/main/java/com/iny/side/assignment/application/service/StudentAssignmentServiceImpl.java
@@ -2,22 +2,18 @@ package com.iny.side.assignment.application.service;
 
 import com.iny.side.assignment.domain.entity.Assignment;
 import com.iny.side.assignment.domain.repository.AssignmentRepository;
-import com.iny.side.assignment.web.dto.AssignmentSimpleResponseDto;
 import com.iny.side.assignment.web.dto.StudentAssignmentDetailResponseDto;
 import com.iny.side.assignment.web.dto.StudentAssignmentSimpleResponseDto;
 import com.iny.side.common.SliceResponse;
 import com.iny.side.common.exception.ForbiddenException;
 import com.iny.side.common.exception.NotFoundException;
 import com.iny.side.course.application.service.EnrollmentValidationService;
-import com.iny.side.submission.domain.entity.Submission;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
 @Builder

--- a/src/main/java/com/iny/side/assignment/web/dto/StudentAssignmentSimpleResponseDto.java
+++ b/src/main/java/com/iny/side/assignment/web/dto/StudentAssignmentSimpleResponseDto.java
@@ -6,14 +6,14 @@ import com.iny.side.submission.domain.entity.Submission.SubmissionStatus;
 import java.time.LocalDateTime;
 
 public record StudentAssignmentSimpleResponseDto(Long id, String title, LocalDateTime dueDate, String objective,
-                                                 SubmissionStatus status) {
+                                                 String status) {
     public static StudentAssignmentSimpleResponseDto from(Assignment assignment, SubmissionStatus status) {
         return new StudentAssignmentSimpleResponseDto(
                 assignment.getId(),
                 assignment.getTitle(),
                 assignment.getDueDate(),
                 assignment.getObjective(),
-                status != null ? status : SubmissionStatus.NOT_STARTED
+                status != null ? status.toString() : "NOT_STARTED"
         );
     }
 }

--- a/src/main/java/com/iny/side/submission/domain/entity/Submission.java
+++ b/src/main/java/com/iny/side/submission/domain/entity/Submission.java
@@ -85,7 +85,7 @@ public class Submission {
 
     public enum SubmissionStatus {
         NOT_STARTED, // 진행전
-        DRAFT,      // 진행 중
-        SUBMITTED   // 제출 완료
+        DRAFT,       // 진행 중
+        SUBMITTED    // 제출 완료
     }
 }

--- a/src/main/java/com/iny/side/submission/domain/entity/Submission.java
+++ b/src/main/java/com/iny/side/submission/domain/entity/Submission.java
@@ -1,7 +1,6 @@
 package com.iny.side.submission.domain.entity;
 
 import com.iny.side.assignment.domain.entity.Assignment;
-import com.iny.side.chat.domain.entity.ChatMessage;
 import com.iny.side.submission.exception.InvalidSubmissionDataException;
 import com.iny.side.users.domain.entity.Account;
 import jakarta.persistence.*;
@@ -11,8 +10,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @Entity
@@ -49,10 +46,10 @@ public class Submission {
     private SubmissionStatus status = SubmissionStatus.DRAFT;
 
     @Builder
-    public Submission(Long id, Account student, Assignment assignment, 
-                     String primaryDiagnosis, String subDiagnosis, 
-                     String finalJudgment, LocalDateTime submittedAt, 
-                     SubmissionStatus status) {
+    public Submission(Long id, Account student, Assignment assignment,
+                      String primaryDiagnosis, String subDiagnosis,
+                      String finalJudgment, LocalDateTime submittedAt,
+                      SubmissionStatus status) {
         this.id = id;
         this.student = student;
         this.assignment = assignment;


### PR DESCRIPTION
## ✨ 작업 개요
<!-- 어떤 작업을 했는지 한 줄로 설명해주세요 -->
학생의 과제 목록 조회 시, **교수의 채점 완료 여부를 포함한 모든 과제 상태(GRADED, SUBMITTED, DRAFT, NOT_STARTED)** 가 표시되도록 조회 로직을 개선하고 관련 코드를 리팩토링했습니다.

---

## 🛠️ 주요 변경 사항
<!-- 변경된 내용을 bullet 형식으로 요약해주세요 -->
- **과제 상태 결정 로직 리팩토링**: 기존에 서비스 계층에서 status가 null일 때 NOT_STARTED로 처리하던 로직을 JPQL의 CASE 구문을 사용하여 데이터베이스 조회 시점에 처리하도록 책임을 이동했습니다.
- **'채점 완료' 상태 추가**: Evaluation 테이블을 LEFT JOIN하여, 학생이 제출한 과제에 대한 평가가 존재할 경우 상태를 GRADED로 표시하도록 개선했습니다.
- **DTO 타입 변경**: 확장된 상태(GRADED)를 유연하게 처리하기 위해 StudentAssignmentSimpleResponseDto의 status 필드 타입을 SubmissionStatus Enum에서 String으로 변경했습니다.

---

## 🧪 테스트 방법
<!-- 직접 확인하거나, QA가 테스트할 수 있도록 설명(화면 테스트) -->
1. 학생으로 로그인하여 수강 중인 강좌의 과제 목록 페이지 진입
2. 다양한 상태의 과제들이 올바르게 표시되는지 확인:
    - 시작하지 않은 과제: NOT_STARTED
    - 작성 중인 과제: DRAFT
    - 제출 완료한 과제: SUBMITTED
    - 교수가 채점 완료한 과제: GRADED
3. 페이징 처리가 정상적으로 동작하는지 확인


---

## 🤝 리뷰 요청 포인트
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있다면 적어주세요 -->
- JPQL의 복잡한 CASE WHEN 구문이 성능상 문제없는지 검토 요청
- String 타입으로 변경된 status 필드의 타입 안정성
